### PR TITLE
Cmsmcq patch iso 639

### DIFF
--- a/_i18n/en/conferences/conferences.md
+++ b/_i18n/en/conferences/conferences.md
@@ -24,14 +24,15 @@ In order to share information and coordinate efforts of on site community transl
 Examples (given a request to translate from French to English at session 314 of the DH2016 Conference):
 
 - \#DH2016 #tr314
-- \#DH2016 #FrEn314
+- \#DH2016 #fr-en-314
+- \#DH2016 #fra-eng-314
 
 If translation efforts are taking place outside of twitter, descriptive links will also help interested volunteers keep track of the activities.
 
 Examples (given a request to translate from French to English at session 314 of the DH2016 Conference):
 
 - bit.ly/dh2016tr314
-- bit.ly/trFrEn314
+- bit.ly/tr-fr-en-314
 
 
 **Conference Whispering Tools**

--- a/_i18n/en/conferences/conferences.md
+++ b/_i18n/en/conferences/conferences.md
@@ -27,6 +27,11 @@ Examples (given a request to translate from French to English at session 314 of 
 - \#DH2016 #fr-en-314
 - \#DH2016 #fra-eng-314
 
+For channels which don't support the notion of secondary hashtags, concatenate the tags:
+
+- \#DH2016-tr314
+- \#DH2016-fra-eng-314
+
 If translation efforts are taking place outside of twitter, descriptive links will also help interested volunteers keep track of the activities.
 
 Examples (given a request to translate from French to English at session 314 of the DH2016 Conference):

--- a/_i18n/es/conferences/conferences.md
+++ b/_i18n/es/conferences/conferences.md
@@ -24,14 +24,15 @@ Con el objeto de compartir información y coordinar esfuerzos de traducción com
 Ejemplos: (en el caso de una petición para traducir del francés al inglés en la sesión 314 de DH2016):
 
 - \#DH2016 \#tr314
-- \#DH2016 \#FrEn314
+- \#DH2016 \#fr-en-314
+- \#DH2016 \#fra-eng-314
 
 Si los esfuerzos de traducción se realizan fuera de Twitter, vínculos descriptivos ayudarán a que los voluntarios y otros interesados estén al tanto de las actividades.
 
 Ejemplos (utilizando el mismo caso de arriba):
 
 - bit.ly/dh2016tr314
-- bit.ly/trFrEn314
+- bit.ly/tr-fr-en-314
 
 
 **Herramientas para murmurar en conferencias**

--- a/_i18n/es/conferences/conferences.md
+++ b/_i18n/es/conferences/conferences.md
@@ -27,6 +27,11 @@ Ejemplos: (en el caso de una petición para traducir del francés al inglés en 
 - \#DH2016 \#fr-en-314
 - \#DH2016 \#fra-eng-314
 
+Para los canales que no apoyan las subetiquetas, encadenan las etiquetas:
+
+- \#DH2016-tr314
+- \#DH2016-fr-en-314
+
 Si los esfuerzos de traducción se realizan fuera de Twitter, vínculos descriptivos ayudarán a que los voluntarios y otros interesados estén al tanto de las actividades.
 
 Ejemplos (utilizando el mismo caso de arriba):


### PR DESCRIPTION
This patch changes the examples of ISO 639 language codes to use lower-case (fr not Fr, for example), and adds hyphens to separate language codes from each other since camelcase is no longer providing a visual clue of the boundary.

Strictly speaking, the change is probably unnecessary:  language codes are supposed to be case insensitive, so it's not strictly wrong to use camel case.  But I believe recommended practice is lower-case.

Since the link is to a list of codes from ISO 639-2 (three-letter codes), I've also added a three-letter example.

And also added a suggestion for tags / channel names that do not support the notion of 'sub-tags' (like IRC channel names):  just use a hyphen to separate main tag from subtag.